### PR TITLE
Bugfix: typo of print function of Lesson 7.1

### DIFF
--- a/Lesson/7.1 Functions.ipynb
+++ b/Lesson/7.1 Functions.ipynb
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "def greet_user(name):\n",
-    "    print(\"Hello,\" name)\n",
+    "    print(\"Hello\", name)\n",
     "\n",
     "greet_user(\"Zumi\")"
    ]


### PR DESCRIPTION
In lesson 7.1, the comma "," of print function is missing and raise error.